### PR TITLE
Add BCH and EVM support to bridgeless tx pusher

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import { asCouchCredentials } from 'edge-server-tools'
 export const asConfig = asObject({
   httpPort: asOptional(asNumber, 8008),
   couchMainCluster: asOptional(asString, 'wusa'),
+  etherscanApiKey: asOptional(asString, ''),
   couchUris: asOptional(asCouchCredentials, () => ({
     wusa: {
       url: 'https://autobot.edge.app:6984',

--- a/src/server/bots/bridgeless/txidSubmissionService.ts
+++ b/src/server/bots/bridgeless/txidSubmissionService.ts
@@ -52,7 +52,9 @@ const asBitcoinTransaction = asObject({
   blockHeight: asNumber
 })
 const getBitcoinTransactionHeight = async (txid: string): Promise<number> => {
-  const json = await doFetch(`${BITCOIN_BLOCKBOOK_URL}/tx/${txid}`)
+  const json = await doFetch(
+    `${BITCOIN_BLOCKBOOK_URL}/tx/${txid.replace(/^0x/, '')}`
+  )
   const clean = asBitcoinTransaction(json)
   return Math.max(clean.blockHeight, 0)
 }
@@ -131,7 +133,7 @@ const getZanoTransactionHeight = async (txid: string): Promise<number> => {
     jsonrpc: '2.0',
     method: 'get_tx_details',
     params: {
-      tx_hash: txid
+      tx_hash: txid.replace(/^0x/, '')
     }
   }
   const opts = {

--- a/src/server/bots/bridgeless/txidSubmissionService.ts
+++ b/src/server/bots/bridgeless/txidSubmissionService.ts
@@ -1,5 +1,13 @@
-import { asNumber, asObject, asValue } from 'cleaners'
+import {
+  asEither,
+  asNull,
+  asNumber,
+  asObject,
+  asString,
+  asValue
+} from 'cleaners'
 
+import { config } from '../../../config'
 import type { BridgelessSubmission } from './types'
 
 const doFetch = async (
@@ -59,6 +67,97 @@ const getBlockbookTransactionHeight =
     const json = await doFetch(`${blockbookUrl}/tx/${txid.replace(/^0x/, '')}`)
     const clean = asBlockbookTransaction(json)
     return Math.max(clean.blockHeight, 0)
+  }
+
+const ETHERSCAN_API_URL = 'https://api.etherscan.io/v2/api'
+
+const asEthRpcBlockNumber = asObject({
+  result: asString
+})
+
+const asEthRpcTransactionReceipt = asObject({
+  result: asEither(
+    asObject({
+      blockNumber: asString
+    }),
+    asNull
+  )
+})
+
+const hexQuantityToNumber = (hex: string): number => {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex
+  if (cleanHex === '') return 0
+  const num = parseInt(cleanHex, 16)
+  if (isNaN(num)) throw new Error(`Invalid hex quantity: ${hex}`)
+  return num
+}
+
+const asEtherscanError = asObject({
+  status: asValue('0'),
+  message: asString,
+  result: asString
+})
+
+const doEtherscanFetch = async (
+  chainId: string,
+  method: string,
+  params: unknown[]
+): Promise<unknown> => {
+  const txHash =
+    method === 'eth_getTransactionReceipt' &&
+    typeof params[0] === 'string' &&
+    params[0] !== ''
+      ? `&txhash=${params[0]}`
+      : ''
+  const url =
+    `${ETHERSCAN_API_URL}?chainid=${chainId}` +
+    `&module=proxy&action=${method}${txHash}` +
+    `&apikey=${config.etherscanApiKey}`
+  const json = await doFetch(url)
+
+  try {
+    const etherscanError = asEtherscanError(json)
+    throw new Error(`Etherscan ${method} failed: ${etherscanError.result}`)
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('Etherscan ')) throw e
+  }
+
+  if (
+    json != null &&
+    typeof json === 'object' &&
+    'error' in json &&
+    json.error != null
+  ) {
+    const message =
+      typeof json.error === 'object' &&
+      json.error != null &&
+      'message' in json.error &&
+      typeof json.error.message === 'string'
+        ? json.error.message
+        : 'Unknown RPC error'
+    throw new Error(`RPC ${method} failed: ${message}`)
+  }
+
+  return json
+}
+
+export const getEtherscanChainHeight =
+  (chainId: string) => async (): Promise<number> => {
+    const json = await doEtherscanFetch(chainId, 'eth_blockNumber', [])
+    const clean = asEthRpcBlockNumber(json)
+    return hexQuantityToNumber(clean.result)
+  }
+
+export const getEtherscanTransactionHeight =
+  (chainId: string) =>
+  async (txid: string): Promise<number> => {
+    const json = await doEtherscanFetch(chainId, 'eth_getTransactionReceipt', [
+      txid.startsWith('0x') ? txid : `0x${txid}`
+    ])
+    const clean = asEthRpcTransactionReceipt(json)
+    return clean.result == null
+      ? 0
+      : hexQuantityToNumber(clean.result.blockNumber)
   }
 
 const ZANO_RPC_URL = 'http://37.27.100.59:10500'
@@ -166,6 +265,21 @@ export const chainUtils: Record<
   '5': {
     getChainHeight: getBlockbookChainHeight(BITCOIN_CASH_BLOCKBOOK_URL),
     getTxHeight: getBlockbookTransactionHeight(BITCOIN_CASH_BLOCKBOOK_URL)
+  },
+  // Ethereum
+  '1': {
+    getChainHeight: getEtherscanChainHeight('1'),
+    getTxHeight: getEtherscanTransactionHeight('1')
+  },
+  // BNB Smart Chain
+  '56': {
+    getChainHeight: getEtherscanChainHeight('56'),
+    getTxHeight: getEtherscanTransactionHeight('56')
+  },
+  // Base
+  '8453': {
+    getChainHeight: getEtherscanChainHeight('8453'),
+    getTxHeight: getEtherscanTransactionHeight('8453')
   },
   // Zano
   '2': {

--- a/src/server/bots/bridgeless/txidSubmissionService.ts
+++ b/src/server/bots/bridgeless/txidSubmissionService.ts
@@ -36,28 +36,30 @@ export const getRequiredConfirmations = async (
 }
 
 const BITCOIN_BLOCKBOOK_URL = 'https://btc-wusa1.edge.app/api/v2'
+const BITCOIN_CASH_BLOCKBOOK_URL = 'https://bch-eusa1.edge.app/api/v2'
 
-const asBitcoinBlockbookInfo = asObject({
+const asBlockbookInfo = asObject({
   blockbook: asObject({
     bestHeight: asNumber
   })
 })
-const getBitcoinChainHeight = async (): Promise<number> => {
-  const json = await doFetch(`${BITCOIN_BLOCKBOOK_URL}/`)
-  const clean = asBitcoinBlockbookInfo(json)
-  return clean.blockbook.bestHeight
-}
+const getBlockbookChainHeight =
+  (blockbookUrl: string) => async (): Promise<number> => {
+    const json = await doFetch(`${blockbookUrl}/`)
+    const clean = asBlockbookInfo(json)
+    return clean.blockbook.bestHeight
+  }
 
-const asBitcoinTransaction = asObject({
+const asBlockbookTransaction = asObject({
   blockHeight: asNumber
 })
-const getBitcoinTransactionHeight = async (txid: string): Promise<number> => {
-  const json = await doFetch(
-    `${BITCOIN_BLOCKBOOK_URL}/tx/${txid.replace(/^0x/, '')}`
-  )
-  const clean = asBitcoinTransaction(json)
-  return Math.max(clean.blockHeight, 0)
-}
+const getBlockbookTransactionHeight =
+  (blockbookUrl: string) =>
+  async (txid: string): Promise<number> => {
+    const json = await doFetch(`${blockbookUrl}/tx/${txid.replace(/^0x/, '')}`)
+    const clean = asBlockbookTransaction(json)
+    return Math.max(clean.blockHeight, 0)
+  }
 
 const ZANO_RPC_URL = 'http://37.27.100.59:10500'
 
@@ -157,8 +159,13 @@ export const chainUtils: Record<
 > = {
   // bitcoin
   '0': {
-    getChainHeight: getBitcoinChainHeight,
-    getTxHeight: getBitcoinTransactionHeight
+    getChainHeight: getBlockbookChainHeight(BITCOIN_BLOCKBOOK_URL),
+    getTxHeight: getBlockbookTransactionHeight(BITCOIN_BLOCKBOOK_URL)
+  },
+  // bitcoin cash
+  '5': {
+    getChainHeight: getBlockbookChainHeight(BITCOIN_CASH_BLOCKBOOK_URL),
+    getTxHeight: getBlockbookTransactionHeight(BITCOIN_CASH_BLOCKBOOK_URL)
   },
   // Zano
   '2': {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new external RPC integrations (Blockbook + Etherscan) and a new required config secret (`etherscanApiKey`), which could affect deposit processing if misconfigured or if upstream APIs change/ratelimit.
> 
> **Overview**
> Extends the bridgeless txid submission service to support **Bitcoin Cash** and several **EVM chains** by adding chain-height/tx-height resolvers for BCH (Blockbook) and Ethereum/BNB/Base (Etherscan proxy API).
> 
> Generalizes the previous Bitcoin Blockbook logic into reusable helpers, normalizes txid formatting by stripping/adding `0x` where needed (including for Zano), and adds `etherscanApiKey` to `serverConfig.json`-backed config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1a0a43496ec2d0b4b8790f301314bf763fe2c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213842326501636